### PR TITLE
Actualiza metodo setCaratula

### DIFF
--- a/lib/Sii/EnvioDte.php
+++ b/lib/Sii/EnvioDte.php
@@ -10,7 +10,7 @@
  * 3 de la Licencia, o (a su elección) cualquier versión posterior de la
  * misma.
  *
- * Este programa se distribuye con la esperanza de que sea útil, pero
+ * Este programa se distribuye con la esperanza de que sea útil, perosetCaratula
  * SIN GARANTÍA ALGUNA; ni siquiera la garantía implícita
  * MERCANTIL o de APTITUD PARA UN PROPÓSITO DETERMINADO.
  * Consulte los detalles de la Licencia Pública General Affero de GNU para
@@ -107,6 +107,9 @@ class EnvioDte extends \sasco\LibreDTE\Sii\Base\Envio
             'TmstFirmaEnv' => date('Y-m-d\TH:i:s'),
             'SubTotDTE' => $SubTotDTE,
         ], $caratula);
+        
+        $this->arreglo[$this->config['tipos'][$this->tipo]]['SetDTE']['Caratula'] = $this->caratula;
+
         return true;
     }
 


### PR DESCRIPTION
Setea arreglo para tener disponible desde el método getCaratula() los datos de la carátula que fueron utilizados en el envío.

Code: $this->arreglo[$this->config['tipos'][$this->tipo]]['SetDTE']['Caratula'] = $this->caratula;